### PR TITLE
Dynamically obtain "season" number for NFO usage

### DIFF
--- a/src/onepace_assistant/__init__.py
+++ b/src/onepace_assistant/__init__.py
@@ -1,3 +1,3 @@
 """One Pace Assistant - Download and organize One Pace files."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/src/onepace_assistant/cli.py
+++ b/src/onepace_assistant/cli.py
@@ -309,7 +309,7 @@ def download(
 
         # Generate episode NFOs
         video_files = [f for f in downloaded_files if f.suffix.lower() in (".mkv", ".mp4", ".avi")]
-        generate_arc_nfos(arc, video_files, arc_output_dir)
+        generate_arc_nfos(arc, video_files, arc_output_dir, arcs=arcs)
 
         if not quiet:
             console.print(f"[green]Generated {len(video_files) + 1} NFO files[/green]")
@@ -423,7 +423,7 @@ def generate_nfo_cmd(ctx: click.Context, input_dir: Path, posters_dir: Path | No
             continue
 
         # Generate episode NFOs
-        nfo_paths = generate_arc_nfos(arc, video_files, arc_dir)
+        nfo_paths = generate_arc_nfos(arc, video_files, arc_dir, arcs=arcs)
         results["nfo_generated"] += len(nfo_paths)
         if not quiet:
             console.print(

--- a/src/onepace_assistant/nfo.py
+++ b/src/onepace_assistant/nfo.py
@@ -44,16 +44,30 @@ def generate_tvshow_nfo(output_path: Path) -> Path:
 
     return nfo_path
 
+def _get_season_number(arc: Arc, arcs: list[Arc]) -> int:
+    """Get season number based on slug's position in arc list."""
+    # start=1 because most tv shows don't start at season 0.
+    for i, a in enumerate(arcs, start=1):
+        if a.slug == arc.slug:
+            return i
+    # Fail back to 1 if it doesn't match for some reason.
+    return 1
 
 def generate_episode_nfo(
     arc: Arc,
     episode_number: int,
     video_filename: str,
     output_dir: Path,
-    season_number: int = 1,
+    season_number: int | None = None,
+    arcs: list[Arc] | None = None,
 ) -> Path:
     """Generate an episode NFO file."""
     root = ET.Element("episodedetails")
+
+    if season_number is None and arcs is not None:
+        season_number = _get_season_number(arc, arcs)
+    elif season_number is None:
+        season_number = 1
 
     # Episode title: "Arc Title - Episode Number" or just video filename stem
     episode_title = f"{arc.title} {episode_number:02d}"
@@ -87,7 +101,8 @@ def generate_arc_nfos(
     arc: Arc,
     video_files: list[Path],
     output_dir: Path,
-    season_number: int = 1,
+    season_number: int | None = None,
+    arcs: list[Arc] | None = None
 ) -> list[Path]:
     """Generate NFO files for all episodes in an arc."""
     nfo_paths = []
@@ -102,6 +117,7 @@ def generate_arc_nfos(
             video_filename=video_file.name,
             output_dir=output_dir,
             season_number=season_number,
+            arcs=arcs,
         )
         nfo_paths.append(nfo_path)
 

--- a/tests/test_nfo.py
+++ b/tests/test_nfo.py
@@ -7,7 +7,7 @@ from xml.etree import ElementTree as ET
 import pytest
 
 from onepace_assistant.models import Arc
-from onepace_assistant.nfo import generate_episode_nfo, generate_tvshow_nfo
+from onepace_assistant.nfo import generate_episode_nfo, generate_tvshow_nfo, _get_season_number
 
 
 class TestGenerateTvshowNfo:
@@ -89,3 +89,68 @@ class TestGenerateEpisodeNfo:
             assert root.find("season").text == "1"
             assert root.find("episode").text == "3"
             assert root.find("showtitle").text == "One Pace"
+
+    def test_get_season_number_from_arcs(self, sample_arc):
+        # Since we're already testing with Romance Dawn we add a made up
+        # arc so we don't get the default return of 1 and get 2 instead
+        arcs = [
+            Arc(slug="made-up",
+                title="Made up so we don't get 1",
+                special=False,
+                chapters="0",
+                episodes="0",
+                playGroups=[],
+                ),
+            sample_arc,
+            Arc(slug="orange-town",
+                title="Orange Town",
+                special=False,
+                chapters="8-21",
+                episodes="4-8",
+                playGroups=[],
+                ),
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            nfo_path = generate_episode_nfo(
+                arc=sample_arc,
+                episode_number=3,
+                video_filename="Romance Dawn 03.mkv",
+                output_dir=output_dir,
+                arcs=arcs,
+            )
+
+            tree = ET.parse(nfo_path)
+            root = tree.getroot()
+            assert root.find("season").text == "2"
+        
+        def test_season_number_falls_back_to_one(self, sample_arc):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                output_dir = Path(tmpdir)
+                nfo_path = generate_episode_nfo(
+                    arc=sample_arc,
+                    episode_number=3,
+                    video_filename="Romance Dawn 03.mkv",
+                    output_dir=output_dir,
+                )
+
+                tree = ET.parse(nfo_path)
+                root = tree.getroot()
+                assert root.find("season").text == "1"
+        
+        def test_explicit_season_number_overrides_arcs(self, sample_arc):
+            arcs = [sample_arc]
+            with tempfile.TemporaryDirectory() as tmpdir:
+                output_dir = Path(tmpdir)
+                nfo_path = generate_episode_nfo(
+                    arc=sample_arc,
+                    episode_number=3,
+                    video_filename="Romance Dawn 03.mkv",
+                    output_dir=output_dir,
+                    season_number=5,
+                    arcs=arcs
+                )
+
+            tree = ET.parse(nfo_path)
+            root = tree.getroot()
+            assert root.find("season").text == "5"


### PR DESCRIPTION
Currently, all the seasons have "season 1" in their NFOs. This confuses Jellyfin and it puts episodes in different seasons when it collects the metadata. To solve this, I have added function to get the season number based on the slug's position in the arc list. I've also added tests for these new functions as well.

However, I'm not 100% I'm happy with the tests. It might be better t o create a `def sample_arc_list` or something instead of the way I handled it (creating arc lists in the function).