### PR TITLE
pixeldrain api key support

### DIFF
--- a/src/onepace_assistant/cli.py
+++ b/src/onepace_assistant/cli.py
@@ -13,6 +13,7 @@ from .downloader import (
     download_playlist_zip_sync,
     fetch_playlist_files_sync,
     format_size,
+    validate_api_key_sync,
 )
 from .nfo import generate_arc_nfos, generate_tvshow_nfo
 from .poster_utils import copy_poster_to_arc_dir, find_poster_for_arc
@@ -178,6 +179,12 @@ def info(ctx: click.Context, arc_slug: str) -> None:
     default=None,
     help="Optional: Directory containing poster images to copy after download",
 )
+@click.option(
+    "--pixeldrain-api-key",
+    default=None,
+    envvar="PIXELDRAIN_API_KEY",
+    help="Pixeldrain API key for authenticated requests",
+)
 @click.pass_context
 def download(
     ctx: click.Context,
@@ -192,9 +199,18 @@ def download(
     resume: bool,
     method: str,
     posters_dir: Path | None,
+    pixeldrain_api_key: str | None,
 ) -> None:
     """Download an arc."""
     quiet = ctx.obj.get("quiet", False)
+
+    # Validate API key before doing anything else
+    if pixeldrain_api_key:
+        try:
+            validate_api_key_sync(pixeldrain_api_key)
+        except DownloadError as e:
+            console.print(f"[red]{e}[/red]")
+            raise SystemExit(1)
 
     # Fetch metadata
     if not quiet:
@@ -252,7 +268,7 @@ def download(
     if dry_run:
         console.print("\n[yellow]DRY RUN - No files will be downloaded[/yellow]\n")
 
-        file_list = fetch_playlist_files_sync(playlist)
+        file_list = fetch_playlist_files_sync(playlist, api_key=pixeldrain_api_key)
         total_size = sum(f.size for f in file_list.files)
 
         table = Table(title="Files to Download")
@@ -280,21 +296,21 @@ def download(
             if not quiet:
                 console.print("[dim]💡 Tip: Use --method zip to download all as a single archive. This may help delay rate limits.[/dim]\n")
             # Force individual file downloads
-            downloaded_files = download_playlist_sync(playlist, arc_output_dir, resume=resume)
+            downloaded_files = download_playlist_sync(playlist, arc_output_dir, resume=resume, api_key=pixeldrain_api_key)
         elif method == "zip":
             # Force zip download
-            downloaded_files = download_playlist_zip_sync(playlist, arc_output_dir, resume=resume)
+            downloaded_files = download_playlist_zip_sync(playlist, arc_output_dir, resume=resume, api_key=pixeldrain_api_key)
         else:  # auto
             # Try zip first, fallback to individual on error
             try:
-                downloaded_files = download_playlist_zip_sync(playlist, arc_output_dir, resume=resume)
+                downloaded_files = download_playlist_zip_sync(playlist, arc_output_dir, resume=resume, api_key=pixeldrain_api_key)
             except (DownloadError, Exception) as e:
                 if not quiet:
                     console.print(
                         f"[yellow]Zip download failed ({e}), "
                         "falling back to individual downloads[/yellow]"
                     )
-                downloaded_files = download_playlist_sync(playlist, arc_output_dir, resume=resume)
+                downloaded_files = download_playlist_sync(playlist, arc_output_dir, resume=resume, api_key=pixeldrain_api_key)
     except Exception as e:
         console.print(f"[red]Download failed: {e}[/red]")
         raise SystemExit(1)

--- a/src/onepace_assistant/downloader.py
+++ b/src/onepace_assistant/downloader.py
@@ -54,12 +54,13 @@ async def fetch_playlist_files(playlist: Playlist) -> PixelDrainList:
     )
 
 
-def fetch_playlist_files_sync(playlist: Playlist) -> PixelDrainList:
+def fetch_playlist_files_sync(playlist: Playlist, api_key: str | None = None) -> PixelDrainList:
     """Synchronous version of fetch_playlist_files."""
     url = f"{PIXELDRAIN_API_URL}/list/{playlist.id}"
+    auth = ("", api_key) if api_key else None
 
     with httpx.Client(timeout=30.0) as client:
-        response = client.get(url)
+        response = client.get(url, auth=auth)
         response.raise_for_status()
         data = response.json()
 
@@ -78,6 +79,19 @@ def fetch_playlist_files_sync(playlist: Playlist) -> PixelDrainList:
         download_href=data.get("download_href"),
         files=files,
     )
+
+
+def validate_api_key_sync(api_key: str) -> None:
+    """Validate a PixeldDrain API key against the /api/user endpoint.
+
+    Raises DownloadError if the key is invalid or the request fails.
+    """
+    with httpx.Client(timeout=10.0) as client:
+        response = client.get(f"{PIXELDRAIN_API_URL}/user", auth=("", api_key))
+
+    if response.status_code == 401:
+        raise DownloadError("Invalid PixelDrain API key")
+    response.raise_for_status()
 
 
 def _get_download_url(file_id: str) -> str:
@@ -118,6 +132,7 @@ def download_file_sync(
     output_dir: Path,
     progress: Progress,
     task_id: TaskID,
+    api_key: str | None = None,
 ) -> Path:
     """Synchronous version of download_file."""
     output_path = output_dir / file.name
@@ -128,9 +143,10 @@ def download_file_sync(
         return output_path
 
     url = _get_download_url(file.id)
+    auth = ("", api_key) if api_key else None
 
     with httpx.Client(timeout=None) as client:
-        with client.stream("GET", url) as response:
+        with client.stream("GET", url, auth=auth) as response:
             response.raise_for_status()
 
             with open(output_path, "wb") as f:
@@ -145,6 +161,7 @@ def download_playlist_sync(
     playlist: Playlist,
     output_dir: Path,
     resume: bool = True,
+    api_key: str | None = None,
 ) -> list[Path]:
     """Download all files from a playlist with progress display."""
     # Ensure output directory exists
@@ -152,7 +169,7 @@ def download_playlist_sync(
 
     # Fetch file list
     console.print(f"[cyan]Fetching file list from PixelDrain...[/cyan]")
-    file_list = fetch_playlist_files_sync(playlist)
+    file_list = fetch_playlist_files_sync(playlist, api_key=api_key)
 
     if not file_list.files:
         console.print("[yellow]No files found in playlist[/yellow]")
@@ -189,7 +206,7 @@ def download_playlist_sync(
             )
 
             try:
-                path = download_file_sync(file, output_dir, progress, task_id)
+                path = download_file_sync(file, output_dir, progress, task_id, api_key=api_key)
                 downloaded_paths.append(path)
             except Exception as e:
                 console.print(f"[red]Error downloading {file.name}: {e}[/red]")
@@ -202,6 +219,7 @@ def download_playlist_zip_sync(
     playlist: Playlist,
     output_dir: Path,
     resume: bool = True,
+    api_key: str | None = None,
 ) -> list[Path]:
     """Download all files from a playlist as a single zip archive.
     
@@ -213,7 +231,7 @@ def download_playlist_zip_sync(
 
     # Fetch file list to get download_href and file info
     console.print("[cyan]Fetching playlist info from PixelDrain...[/cyan]")
-    file_list = fetch_playlist_files_sync(playlist)
+    file_list = fetch_playlist_files_sync(playlist, api_key=api_key)
 
     if not file_list.files:
         console.print("[yellow]No files found in playlist[/yellow]")
@@ -247,6 +265,7 @@ def download_playlist_zip_sync(
         tmp_path = Path(tmp_file.name)
 
     try:
+        auth = ("", api_key) if api_key else None
         with Progress(
             TextColumn("[bold blue]Downloading zip", justify="right"),
             BarColumn(bar_width=None),
@@ -260,7 +279,7 @@ def download_playlist_zip_sync(
             console=console,
         ) as progress:
             with httpx.Client(timeout=None) as client:
-                with client.stream("GET", zip_url) as response:
+                with client.stream("GET", zip_url, auth=auth) as response:
                     response.raise_for_status()
                     
                     # Use content-length if available, otherwise use our estimate

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -1,9 +1,12 @@
 """Integration tests for CLI playlist selection logic."""
 
+from unittest.mock import patch
+
 import pytest
 from click.testing import CliRunner
 
 from onepace_assistant.cli import cli
+from onepace_assistant.downloader import DownloadError
 from onepace_assistant.models import Arc, PlayGroup, Playlist
 
 
@@ -119,3 +122,42 @@ class TestCLISmartDefaults:
         playlist = mock_arc.get_playlist(resolution=1080, sub="en", dub="ja")
         assert playlist is not None
         assert playlist.id == "ja_1080"
+
+
+class TestApiKeyValidation:
+    """Test --pixeldrain-api-key validation in the download command."""
+
+    @patch("onepace_assistant.cli.validate_api_key_sync", side_effect=DownloadError("Invalid PixelDrain API key"))
+    @patch("onepace_assistant.cli.fetch_metadata_sync")
+    def test_invalid_key_exits_before_fetching_metadata(self, mock_fetch_metadata, mock_validate):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["download", "some-arc", "--pixeldrain-api-key", "bad-key"])
+
+        assert result.exit_code == 1
+        assert "Invalid PixelDrain API key" in result.output
+        mock_fetch_metadata.assert_not_called()
+
+    @patch("onepace_assistant.cli.validate_api_key_sync")
+    @patch("onepace_assistant.cli.fetch_metadata_sync", side_effect=Exception("stop here"))
+    def test_valid_key_proceeds_to_metadata_fetch(self, mock_fetch_metadata, mock_validate):
+        runner = CliRunner()
+        runner.invoke(cli, ["download", "some-arc", "--pixeldrain-api-key", "good-key"])
+
+        mock_validate.assert_called_once_with("good-key")
+        mock_fetch_metadata.assert_called_once()
+
+    @patch("onepace_assistant.cli.validate_api_key_sync")
+    @patch("onepace_assistant.cli.fetch_metadata_sync", side_effect=Exception("stop here"))
+    def test_no_key_skips_validation(self, mock_fetch_metadata, mock_validate):
+        runner = CliRunner()
+        runner.invoke(cli, ["download", "some-arc"], env={"PIXELDRAIN_API_KEY": ""})
+
+        mock_validate.assert_not_called()
+
+    @patch("onepace_assistant.cli.validate_api_key_sync")
+    @patch("onepace_assistant.cli.fetch_metadata_sync", side_effect=Exception("stop here"))
+    def test_key_read_from_env_var(self, mock_fetch_metadata, mock_validate):
+        runner = CliRunner()
+        runner.invoke(cli, ["download", "some-arc"], env={"PIXELDRAIN_API_KEY": "env-key"})
+
+        mock_validate.assert_called_once_with("env-key")

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -2,15 +2,17 @@
 
 import tempfile
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import pytest
 
 from onepace_assistant.downloader import (
+    DownloadError,
     PixelDrainFile,
     PixelDrainList,
     Playlist,
     download_playlist_zip_sync,
+    validate_api_key_sync,
 )
 
 
@@ -72,3 +74,34 @@ class TestZipDownload:
             
             assert len(result) == 2
             assert all(p.exists() for p in result)
+
+
+class TestValidateApiKey:
+    """Tests for validate_api_key_sync."""
+
+    @patch("onepace_assistant.downloader.httpx.Client")
+    def test_valid_key_does_not_raise(self, mock_client_cls):
+        mock_response = mock_client_cls.return_value.__enter__.return_value.get.return_value
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+
+        validate_api_key_sync("valid-key")  # should not raise
+
+    @patch("onepace_assistant.downloader.httpx.Client")
+    def test_invalid_key_raises_download_error(self, mock_client_cls):
+        mock_response = mock_client_cls.return_value.__enter__.return_value.get.return_value
+        mock_response.status_code = 401
+
+        with pytest.raises(DownloadError, match="Invalid PixelDrain API key"):
+            validate_api_key_sync("bad-key")
+
+    @patch("onepace_assistant.downloader.httpx.Client")
+    def test_key_sent_as_basic_auth(self, mock_client_cls):
+        mock_get = mock_client_cls.return_value.__enter__.return_value.get
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.raise_for_status.return_value = None
+
+        validate_api_key_sync("my-api-key")
+
+        _, kwargs = mock_get.call_args
+        assert kwargs["auth"] == ("", "my-api-key")


### PR DESCRIPTION
Adds support for Pixeldrain API keys for authenticated downloads. 

Example: `onepace download romance-dawn --pixeldrain-api-key <SOME_KEY>`

You can also set the key in the environment variable `PIXELDRAIN_API_KEY` and omit specifying it in the command.
The key, if set, will be validated against Pixeldrains API endpoint (application will exit with an error if key is invalid).

Also added some relevant tests.

Fixes #1 