### PR TITLE
fix: seasons are now properly generated for nfos

### DIFF
--- a/src/onepace_assistant/__init__.py
+++ b/src/onepace_assistant/__init__.py
@@ -1,3 +1,3 @@
 """One Pace Assistant - Download and organize One Pace files."""
 
-__version__ = "0.2.0"
+__version__ = "0.4.0"

--- a/src/onepace_assistant/nfo.py
+++ b/src/onepace_assistant/nfo.py
@@ -44,13 +44,14 @@ def generate_tvshow_nfo(output_path: Path) -> Path:
 
     return nfo_path
 
+
 def _get_season_number(arc: Arc, arcs: list[Arc]) -> int:
     """Get season number based on slug's position in arc list."""
     # start=1 because most tv shows don't start at season 0.
     for i, a in enumerate(arcs, start=1):
         if a.slug == arc.slug:
             return i
-    # Fail back to 1 if it doesn't match for some reason.
+    # Fall back to 1 if it doesn't match for some reason.
     return 1
 
 def generate_episode_nfo(

--- a/tests/test_nfo.py
+++ b/tests/test_nfo.py
@@ -7,7 +7,7 @@ from xml.etree import ElementTree as ET
 import pytest
 
 from onepace_assistant.models import Arc
-from onepace_assistant.nfo import generate_episode_nfo, generate_tvshow_nfo, _get_season_number
+from onepace_assistant.nfo import generate_episode_nfo, generate_tvshow_nfo
 
 
 class TestGenerateTvshowNfo:
@@ -123,33 +123,33 @@ class TestGenerateEpisodeNfo:
             tree = ET.parse(nfo_path)
             root = tree.getroot()
             assert root.find("season").text == "2"
-        
-        def test_season_number_falls_back_to_one(self, sample_arc):
-            with tempfile.TemporaryDirectory() as tmpdir:
-                output_dir = Path(tmpdir)
-                nfo_path = generate_episode_nfo(
-                    arc=sample_arc,
-                    episode_number=3,
-                    video_filename="Romance Dawn 03.mkv",
-                    output_dir=output_dir,
-                )
 
-                tree = ET.parse(nfo_path)
-                root = tree.getroot()
-                assert root.find("season").text == "1"
-        
-        def test_explicit_season_number_overrides_arcs(self, sample_arc):
-            arcs = [sample_arc]
-            with tempfile.TemporaryDirectory() as tmpdir:
-                output_dir = Path(tmpdir)
-                nfo_path = generate_episode_nfo(
-                    arc=sample_arc,
-                    episode_number=3,
-                    video_filename="Romance Dawn 03.mkv",
-                    output_dir=output_dir,
-                    season_number=5,
-                    arcs=arcs
-                )
+    def test_season_number_falls_back_to_one(self, sample_arc):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            nfo_path = generate_episode_nfo(
+                arc=sample_arc,
+                episode_number=3,
+                video_filename="Romance Dawn 03.mkv",
+                output_dir=output_dir,
+            )
+
+            tree = ET.parse(nfo_path)
+            root = tree.getroot()
+            assert root.find("season").text == "1"
+
+    def test_explicit_season_number_overrides_arcs(self, sample_arc):
+        arcs = [sample_arc]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = Path(tmpdir)
+            nfo_path = generate_episode_nfo(
+                arc=sample_arc,
+                episode_number=3,
+                video_filename="Romance Dawn 03.mkv",
+                output_dir=output_dir,
+                season_number=5,
+                arcs=arcs
+            )
 
             tree = ET.parse(nfo_path)
             root = tree.getroot()


### PR DESCRIPTION
NOTE: This was fixed in pr 5, using semantic commit message to trigger release update.
