### PR TITLE
fix: update scraper for new site layout and handle field renames

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "onepace-assistant"
-version = "0.4.1"
+version = "0.4.2"
 description = "CLI tool to download and organize One Pace files for media servers"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/onepace_assistant/scraper.py
+++ b/src/onepace_assistant/scraper.py
@@ -29,48 +29,55 @@ def _unescape_rsc_string(s: str) -> str:
 
 
 def _extract_arcs_array(payload: str) -> list[dict]:
-    """Extract the arcs data array from the RSC payload."""
-    # Find the data property containing the arcs array
-    # Pattern: "data":[{"slug":... - we match the start then use bracket counting
-    data_match = re.search(r'"data":\s*(\[{"slug":")', payload, re.DOTALL)
-    if data_match:
+    """Extract the arcs data array from the RSC payload (supports modern and legacy formats)."""
+    # 1. Handle timeline-based segments (current site version)
+    # 2. Fallback for legacy data property structure
+    patterns = [
+        r'"timeline":\s*\{.*?"segments":\s*(\[)',
+        r'"data":\s*(\[{"slug":")'
+    ]
+
+    for pattern in patterns:
+        match = re.search(pattern, payload, re.DOTALL)
+        if not match:
+            continue
+
         # Extract the array using bracket matching
-        start_idx = data_match.start(1)
+        start_idx = match.start(1)
         arr_str = payload[start_idx:]
-        
+
         bracket_count = 0
-        end_idx = 0
         for i, c in enumerate(arr_str):
             if c == '[':
                 bracket_count += 1
             elif c == ']':
                 bracket_count -= 1
                 if bracket_count == 0:
-                    end_idx = i + 1
-                    break
-        
-        if end_idx > 0:
-            try:
-                return json.loads(arr_str[:end_idx])
-            except json.JSONDecodeError:
-                pass
+                    try:
+                        return json.loads(arr_str[:i + 1])
+                    except json.JSONDecodeError:
+                        break  # Try next pattern
 
     raise ScraperError("Could not extract arcs data from RSC payload")
 
 
-def _normalize_undefined(data: dict | list | Any) -> dict | list | Any:
-    """Recursively replace '$undefined' strings with None.
-    
-    onepace.net's RSC payload contains the literal string '$undefined' for
-    fields that should be null/None. This function normalizes those values.
+def _normalize_arc_data(data: Any) -> Any:
     """
+    Recursively normalizes payload data:
+    - Replaces '$undefined' with None.
+    - Maps 'playlistGroups' to 'playGroups' for compatibility with newer site versions.
+    """
+    if isinstance(data, list):
+        return [_normalize_arc_data(item) for item in data]
+
     if isinstance(data, dict):
-        return {k: _normalize_undefined(v) for k, v in data.items()}
-    elif isinstance(data, list):
-        return [_normalize_undefined(item) for item in data]
-    elif data == "$undefined":
-        return None
-    return data
+        normalized = {}
+        for k, v in data.items():
+            key = "playGroups" if k == "playlistGroups" else k
+            normalized[key] = _normalize_arc_data(v)
+        return normalized
+
+    return None if data == "$undefined" else data
 
 
 def extract_rsc_payload(html: str) -> str:
@@ -95,8 +102,8 @@ def parse_arcs_from_html(html: str) -> list[Arc]:
     arcs = []
     for arc_data in arcs_data:
         try:
-            # Normalize $undefined strings to None before validation
-            normalized_data = _normalize_undefined(arc_data)
+            # Normalize data: $undefined -> None, playlistGroups -> playGroups
+            normalized_data = _normalize_arc_data(arc_data)
             arc = Arc.model_validate(normalized_data)
             arcs.append(arc)
         except Exception as e:

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from onepace_assistant.scraper import extract_rsc_payload, _unescape_rsc_string, _normalize_undefined
+from onepace_assistant.scraper import extract_rsc_payload, _unescape_rsc_string, _normalize_arc_data
 
 
 class TestUnescapeRscString:
@@ -18,17 +18,17 @@ class TestUnescapeRscString:
         assert _unescape_rsc_string("path\\\\to\\\\file") == "path\\to\\file"
 
 
-class TestNormalizeUndefined:
-    """Tests for $undefined normalization."""
+class TestNormalizeArcData:
+    """Tests for arc data normalization."""
 
     def test_normalize_dict_with_undefined(self):
         data = {"sub": "$undefined", "dub": "en", "variant": "$undefined"}
-        result = _normalize_undefined(data)
+        result = _normalize_arc_data(data)
         assert result == {"sub": None, "dub": "en", "variant": None}
 
     def test_normalize_list_with_undefined(self):
         data = ["$undefined", "en", "ja", "$undefined"]
-        result = _normalize_undefined(data)
+        result = _normalize_arc_data(data)
         assert result == [None, "en", "ja", None]
 
     def test_normalize_nested_structures(self):
@@ -38,7 +38,7 @@ class TestNormalizeUndefined:
                 {"sub": "en", "dub": "ja", "variant": "$undefined"},
             ]
         }
-        result = _normalize_undefined(data)
+        result = _normalize_arc_data(data)
         assert result == {
             "playGroups": [
                 {"sub": None, "dub": "en", "playlists": []},
@@ -46,13 +46,25 @@ class TestNormalizeUndefined:
             ]
         }
 
+    def test_normalize_playlist_groups_mapping(self):
+        """Test that playlistGroups is mapped to playGroups for compatibility with newer site versions."""
+        data = {
+            "playlistGroups": [
+                {"id": 1, "name": "Standard"}
+            ]
+        }
+        result = _normalize_arc_data(data)
+        assert "playGroups" in result
+        assert "playlistGroups" not in result
+        assert result["playGroups"] == [{"id": 1, "name": "Standard"}]
+
     def test_normalize_preserves_other_values(self):
         data = {
             "title": "Romance Dawn",
             "description": "Test with $undefined in text",
             "sub": "$undefined",
         }
-        result = _normalize_undefined(data)
+        result = _normalize_arc_data(data)
         # Only exact match "$undefined" should be converted
         assert result == {
             "title": "Romance Dawn",


### PR DESCRIPTION
Current version is unable to scrape metadata due to changes in layout.